### PR TITLE
Add basic crafting interface

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
@@ -9,6 +9,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.input.MouseButton;
 import javafx.stage.Screen;
@@ -71,9 +72,15 @@ public class LanceurJeu extends Application {
         Scene scene = new Scene(racine, screenWidth, screenHeight);
 
         Pane pauseOverlay = (Pane) scene.lookup("#pauseOverlay");
+        Pane craftOverlay = (Pane) scene.lookup("#craftOverlay");
+        VBox craftBox = (VBox) scene.lookup("#craftBox");
         if (pauseOverlay != null) {
             pauseOverlay.prefWidthProperty().bind(scene.widthProperty());
             pauseOverlay.prefHeightProperty().bind(scene.heightProperty());
+        }
+        if (craftOverlay != null) {
+            craftOverlay.prefWidthProperty().bind(scene.widthProperty());
+            craftOverlay.prefHeightProperty().bind(scene.heightProperty());
         }
 
         try {
@@ -153,6 +160,7 @@ public class LanceurJeu extends Application {
             ControleurJeu controleurJeu = new ControleurJeu(
                     scene, carte, carteAffichable, joueur,
                     inventaireCtrl, barreVie, labelVie, pauseOverlay,
+                    craftOverlay, craftBox,
                     idle, marche, attaque, preparationSaut, volSaut, sautReload,
                     chute, atterrissage, degats, mort, sort, accroupi, bouclier,
                     loup

--- a/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/VueJeu.fxml
+++ b/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/VueJeu.fxml
@@ -2,8 +2,13 @@
         <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.VBox?>
 <Pane fx:id="racine" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <StackPane fx:id="pauseOverlay" visible="false" style="-fx-background-color: rgba(0,0,0,0.6);">
         <Label text="Jeu en pause&#10;Appuyez sur Entrée pour reprendre" style="-fx-text-fill: white; -fx-font-size: 36px; -fx-text-alignment: center;" />
+    </StackPane>
+    <StackPane fx:id="craftOverlay" visible="false" style="-fx-background-color: rgba(0,0,0,0.3);">
+        <VBox fx:id="craftBox" alignment="CENTER" spacing="10"
+              style="-fx-background-color: rgba(200,200,200,0.8); -fx-border-color: black; -fx-border-width: 2;"/>
     </StackPane>
 </Pane>


### PR DESCRIPTION
## Summary
- add craft overlay area in VueJeu.fxml
- handle `C` key to toggle crafting and populate buttons
- wire new overlay through LanceurJeu

## Testing
- `mvn test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6851e630687c8323966e9284aa9f0b7e