### PR TITLE
Enable right-click resource breaking and fix left-click attack

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -176,31 +176,30 @@ public class ControleurJeu {
                 double xMonde = e.getX() + offsetXProperty.get();
                 double yMonde = e.getY() + offsetYProperty.get();
 
-                double distance = Math.abs(joueur.getX() - loup.getX());
-                if (distance <= PORTEE_ATTAQUE_JOUEUR) {
-                    if (joueur.isBouclierActif()) {
-                        joueur.desactiverBouclier();
-                    }
-                    boolean cliqueLoup = xMonde >= loup.getX() && xMonde <= loup.getX() + vueLoup.getSprite().getFitWidth()
-                            && yMonde >= loup.getY() && yMonde <= loup.getY() + vueLoup.getSprite().getFitHeight();
+                if (joueur.isBouclierActif()) {
+                    joueur.desactiverBouclier();
+                }
 
-                    if (!joueur.estEnAttaque()) {
-                        joueur.attaquer();
-                        animation.reset();
-                        compteurAttaque = 0;
-                        if (cliqueLoup) {
-                            loup.subirDegats(DEGATS_JOUEUR_LOUP);
-                            if (loup.getPointsDeVie() <= 0) {
-                                loupMort = true;
-                            }
+                boolean cliqueLoup = xMonde >= loup.getX() && xMonde <= loup.getX() + vueLoup.getSprite().getFitWidth()
+                        && yMonde >= loup.getY() && yMonde <= loup.getY() + vueLoup.getSprite().getFitHeight();
+                double distance = Math.abs(joueur.getX() - loup.getX());
+
+                if (!joueur.estEnAttaque()) {
+                    joueur.attaquer();
+                    animation.reset();
+                    compteurAttaque = 0;
+                    if (distance <= PORTEE_ATTAQUE_JOUEUR && cliqueLoup) {
+                        loup.subirDegats(DEGATS_JOUEUR_LOUP);
+                        if (loup.getPointsDeVie() <= 0) {
+                            loupMort = true;
                         }
-                    } else {
-                        animation.demandeCombo();
-                        if (cliqueLoup) {
-                            loup.subirDegats(DEGATS_COMBO_SUPPLEMENTAIRES);
-                            if (loup.getPointsDeVie() <= 0) {
-                                loupMort = true;
-                            }
+                    }
+                } else {
+                    animation.demandeCombo();
+                    if (distance <= PORTEE_ATTAQUE_JOUEUR && cliqueLoup) {
+                        loup.subirDegats(DEGATS_COMBO_SUPPLEMENTAIRES);
+                        if (loup.getPointsDeVie() <= 0) {
+                            loupMort = true;
                         }
                     }
                 }

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -170,16 +170,11 @@ public class ControleurJeu {
                 sort, accroupi, bouclier
         );
 
-        // Gestion du clic gauche pour attaquer
+        // Gestion du clic gauche pour attaquer uniquement
         scene.setOnMousePressed(e -> {
             if (e.getButton() == MouseButton.PRIMARY) {
                 double xMonde = e.getX() + offsetXProperty.get();
                 double yMonde = e.getY() + offsetYProperty.get();
-
-                // Priorité : détruire une ressource cliquée si possible
-                if (essayerCasserRessource(xMonde, yMonde)) {
-                    return;
-                }
 
                 double distance = Math.abs(joueur.getX() - loup.getX());
                 if (distance <= PORTEE_ATTAQUE_JOUEUR) {
@@ -211,6 +206,7 @@ public class ControleurJeu {
                 }
             }
         });
+        // Le clic droit gère la destruction des ressources et les blocs
         scene.setOnMouseClicked(e -> {
             if (e.getButton() == MouseButton.SECONDARY) {
                 gererClicDroit(e.getX(), e.getY());
@@ -503,6 +499,9 @@ public class ControleurJeu {
         return false;
     }
 
+    /**
+     * Gère le clic droit : destruction de ressources et interactions avec les blocs.
+     */
     private void gererClicDroit(double xScene, double yScene) {
         double xMonde = xScene + offsetXProperty.get();
         double yMonde = yScene + offsetYProperty.get();


### PR DESCRIPTION
## Summary
- remove resource destruction from left click handler
- document that right click handles resources and blocks
- document right-click handler

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68549327c070832380549c286acfe566