### PR TITLE
Enable attack animation regardless of distance

### DIFF
--- a/src/main/java/fr/iut/groupe/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/fr/iut/groupe/junglequest/controleur/ControleurJeu.java
@@ -181,33 +181,32 @@ public class ControleurJeu {
                     return;
                 }
 
+                boolean cliqueLoup = xMonde >= loup.getX() && xMonde <= loup.getX() + vueLoup.getSprite().getFitWidth()
+                        && yMonde >= loup.getY() && yMonde <= loup.getY() + vueLoup.getSprite().getFitHeight();
                 double distance = Math.abs(joueur.getX() - loup.getX());
-                if (distance <= PORTEE_ATTAQUE_JOUEUR) {
-                    if (joueur.isBouclierActif()) {
-                        joueur.desactiverBouclier();
-                    }
-                    boolean cliqueLoup = xMonde >= loup.getX() && xMonde <= loup.getX() + vueLoup.getSprite().getFitWidth()
-                            && yMonde >= loup.getY() && yMonde <= loup.getY() + vueLoup.getSprite().getFitHeight();
 
-                    if (!joueur.estEnAttaque()) {
-                        joueur.attaquer();
-                        animation.reset();
-                        compteurAttaque = 0;
-                        if (cliqueLoup) {
-                            loup.subirDegats(DEGATS_JOUEUR_LOUP);
-                            if (loup.getPointsDeVie() <= 0) {
-                                loupMort = true;
-                            }
-                        }
-                    } else {
-                        animation.demandeCombo();
-                        if (cliqueLoup) {
-                            loup.subirDegats(DEGATS_COMBO_SUPPLEMENTAIRES);
-                            if (loup.getPointsDeVie() <= 0) {
-                                loupMort = true;
-                            }
+                if (!joueur.estEnAttaque()) {
+                    joueur.attaquer();
+                    animation.reset();
+                    compteurAttaque = 0;
+                    if (distance <= PORTEE_ATTAQUE_JOUEUR && cliqueLoup) {
+                        loup.subirDegats(DEGATS_JOUEUR_LOUP);
+                        if (loup.getPointsDeVie() <= 0) {
+                            loupMort = true;
                         }
                     }
+                } else {
+                    animation.demandeCombo();
+                    if (distance <= PORTEE_ATTAQUE_JOUEUR && cliqueLoup) {
+                        loup.subirDegats(DEGATS_COMBO_SUPPLEMENTAIRES);
+                        if (loup.getPointsDeVie() <= 0) {
+                            loupMort = true;
+                        }
+                    }
+                }
+
+                if (joueur.isBouclierActif()) {
+                    joueur.desactiverBouclier();
                 }
             }
         });

--- a/src/test/java/fr/iut/groupe/junglequest/modele/bloc/TileTypeTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/bloc/TileTypeTest.java
@@ -1,0 +1,20 @@
+package fr.iut.groupe.junglequest.modele.bloc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TileTypeTest {
+    @Test
+    void fromIdRetourneType() {
+        assertEquals(TileType.HERBE, TileType.fromId(1));
+        assertEquals(TileType.VIDE, TileType.fromId(-1));
+        assertNull(TileType.fromId(999));
+    }
+
+    @Test
+    void contientIdFonctionne() {
+        assertTrue(TileType.ARBRE.contientId(160));
+        assertFalse(TileType.TERRE.contientId(1));
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/carte/CarteTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/carte/CarteTest.java
@@ -1,0 +1,47 @@
+package fr.iut.groupe.junglequest.modele.carte;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CarteTest {
+    @Test
+    void getValeurTuileOutOfBounds() {
+        int[][] grid = {{1}};
+        Carte carte = new Carte(grid);
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(-1, 0));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(0, -1));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(1, 0));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(0, 1));
+    }
+
+    @Test
+    void setValeurTuileModifieSiValide() {
+        int[][] grid = {{0,0},{0,0}};
+        Carte carte = new Carte(grid);
+        carte.setValeurTuile(1,1,5);
+        assertEquals(5, carte.getValeurTuile(1,1));
+        carte.setValeurTuile(2,0,9);
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(2,0));
+    }
+
+    @Test
+    void estSolidePrendEnCompteListeNonSolide() {
+        int[][] grid = {{0,29}};
+        Carte carte = new Carte(grid);
+        assertFalse(carte.estSolide(0,0));
+        assertTrue(carte.estSolide(0,1));
+    }
+
+    @Test
+    void chercherLigneSolRenvoieBonneLigne() {
+        int[][] grid = {
+            {-1,-1},
+            {1,0},
+            {29,29}
+        };
+        Carte carte = new Carte(grid);
+        assertEquals(2, carte.chercherLigneSol(0));
+        assertEquals(2, carte.chercherLigneSol(1));
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/item/BlockPlaceTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/item/BlockPlaceTest.java
@@ -1,0 +1,17 @@
+package fr.iut.groupe.junglequest.modele.item;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BlockPlaceTest {
+    @Test
+    void subirDegatsEtDestruction() {
+        BlockPlace bp = new BlockPlace("Bois", 1, 1);
+        bp.subirDegats(3);
+        assertEquals(7, bp.getVie());
+        assertFalse(bp.estDetruit());
+        bp.subirDegats(10);
+        assertEquals(0, bp.getVie());
+        assertTrue(bp.estDetruit());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/item/InventaireTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/item/InventaireTest.java
@@ -1,0 +1,36 @@
+package fr.iut.groupe.junglequest.modele.item;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InventaireTest {
+    @Test
+    void ajouterEtContientItem() {
+        Inventaire inv = new Inventaire();
+        assertTrue(inv.ajouterItem("Bois", 3));
+        assertTrue(inv.contient("Bois", 3));
+        assertFalse(inv.ajouterItem("Pierre", 0));
+    }
+
+    @Test
+    void retirerItemFonctionne() {
+        Inventaire inv = new Inventaire();
+        inv.ajouterItem("Bois", 5);
+
+        assertTrue(inv.retirerItem("Bois", 3));
+        assertEquals(2, inv.getItems().get("Bois"));
+        assertFalse(inv.retirerItem("Bois", 3));
+        assertTrue(inv.retirerItem("Bois", 2));
+        assertFalse(inv.getItems().containsKey("Bois"));
+    }
+
+    @Test
+    void viderSupprimeTout() {
+        Inventaire inv = new Inventaire();
+        inv.ajouterItem("Bois", 1);
+        inv.ajouterItem("Pierre", 2);
+        inv.vider();
+        assertTrue(inv.getItems().isEmpty());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/item/equipement/EquipementTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/item/equipement/EquipementTest.java
@@ -1,0 +1,41 @@
+package fr.iut.groupe.junglequest.modele.item.equipement;
+
+import fr.iut.groupe.junglequest.modele.item.equipement.arme.Arc;
+import fr.iut.groupe.junglequest.modele.personnages.Joueur;
+import fr.iut.groupe.junglequest.modele.Ciblable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EquipementTest {
+    static class DummyTarget implements Ciblable {
+        int pv = 50;
+        final double x; final double y;
+        DummyTarget(double x, double y){ this.x = x; this.y = y; }
+        @Override public String getTypeCible(){ return "Ennemi"; }
+        @Override public void subirDegats(int degats){ pv -= degats; }
+        @Override public double getX(){ return x; }
+        @Override public double getY(){ return y; }
+        @Override public String getNom(){ return "Loup"; }
+    }
+
+    @Test
+    void degatsContreInfligeEtUse() {
+        Joueur j = new Joueur(0,0);
+        Arc arc = new Arc();
+        DummyTarget cible = new DummyTarget(1,1);
+        arc.degatsContre(j, cible);
+        assertEquals(38, cible.pv);
+        assertEquals(18, arc.getDurabilite());
+    }
+
+    @Test
+    void aucunePorteeReduitDurabilite() {
+        Joueur j = new Joueur(0,0);
+        Arc arc = new Arc();
+        DummyTarget cible = new DummyTarget(100,0);
+        arc.degatsContre(j, cible);
+        assertEquals(50, cible.pv);
+        assertEquals(18, arc.getDurabilite());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/monde/AStarTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/monde/AStarTest.java
@@ -1,0 +1,36 @@
+package fr.iut.groupe.junglequest.modele.monde;
+
+import fr.iut.groupe.junglequest.modele.carte.Carte;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AStarTest {
+    @Test
+    void chercherCheminSimple() {
+        int[][] grid = {
+                {0,0,0},
+                {0,29,0},
+                {0,0,0}
+        };
+        Carte carte = new Carte(grid);
+        List<int[]> path = AStar.chercherChemin(carte,0,0,2,2);
+        assertFalse(path.isEmpty());
+        assertArrayEquals(new int[]{0,0}, path.get(0));
+        assertArrayEquals(new int[]{2,2}, path.get(path.size()-1));
+    }
+
+    @Test
+    void chercherCheminBloqueRenvoieVide() {
+        int[][] grid = {
+                {0,29,0},
+                {29,29,29},
+                {0,29,0}
+        };
+        Carte carte = new Carte(grid);
+        List<int[]> path = AStar.chercherChemin(carte,0,0,2,2);
+        assertTrue(path.isEmpty());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/monde/MathsTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/monde/MathsTest.java
@@ -1,0 +1,11 @@
+package fr.iut.groupe.junglequest.modele.monde;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MathsTest {
+    @Test
+    void distanceSimple() {
+        assertEquals(5.0, Maths.distance(0,0,3,4), 0.0001);
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/personnages/EtatTemporaireTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/personnages/EtatTemporaireTest.java
@@ -1,0 +1,20 @@
+package fr.iut.groupe.junglequest.modele.personnages;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EtatTemporaireTest {
+    @Test
+    void appliquerEtExpirationEffet() {
+        EtatTemporaire etat = new EtatTemporaire();
+        etat.appliquerEffet(2.0, true, true);
+        assertTrue(etat.isInvincible());
+        assertTrue(etat.isVulnerable());
+        assertEquals(2.0, etat.getVitesseTemporaire());
+        etat.setEffetFin(System.currentTimeMillis() - 1);
+        etat.verifierExpiration();
+        assertFalse(etat.isInvincible());
+        assertFalse(etat.isVulnerable());
+        assertEquals(1.5, etat.getVitesseTemporaire());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/personnages/PersonnageTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/personnages/PersonnageTest.java
@@ -1,0 +1,46 @@
+package fr.iut.groupe.junglequest.modele.personnages;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersonnageTest {
+
+    static class TestPerso extends Personnage {
+        TestPerso() { super(0,0,10,10); }
+    }
+
+    @Test
+    void sautUniquementAuSol() {
+        TestPerso p = new TestPerso();
+        p.setEstAuSol(true);
+        p.sauter(5);
+        assertEquals(-5, p.getVitesseY());
+        assertFalse(p.estAuSol());
+        p.sauter(5);
+        assertEquals(-5, p.getVitesseY());
+    }
+
+    @Test
+    void appliquerGraviteLimiteLaVitesse() {
+        TestPerso p = new TestPerso();
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        assertEquals(3, p.getVitesseY());
+    }
+
+    @Test
+    void deplacementGaucheDroiteEtArret() {
+        TestPerso p = new TestPerso();
+        p.deplacerDroite(2);
+        assertEquals(2, p.getVitesseX());
+        assertFalse(p.estVersGauche());
+        p.deplacerGauche(1);
+        assertEquals(-1, p.getVitesseX());
+        assertTrue(p.estVersGauche());
+        p.arreter();
+        assertEquals(0, p.getVitesseX());
+    }
+}


### PR DESCRIPTION
## Summary
- trigger player attack on any left click
- only apply damage to the wolf when in range
- deactivate shield when attacking

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855a425ad348323ad1357a0d9ca53a5