### PR TITLE
Add JUnit tests for core classes

### DIFF
--- a/src/test/java/fr/iut/groupe/junglequest/modele/bloc/TileTypeTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/bloc/TileTypeTest.java
@@ -1,0 +1,20 @@
+package fr.iut.groupe.junglequest.modele.bloc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TileTypeTest {
+    @Test
+    void fromIdRetourneType() {
+        assertEquals(TileType.HERBE, TileType.fromId(1));
+        assertEquals(TileType.VIDE, TileType.fromId(-1));
+        assertNull(TileType.fromId(999));
+    }
+
+    @Test
+    void contientIdFonctionne() {
+        assertTrue(TileType.ARBRE.contientId(160));
+        assertFalse(TileType.TERRE.contientId(1));
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/carte/CarteTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/carte/CarteTest.java
@@ -1,0 +1,47 @@
+package fr.iut.groupe.junglequest.modele.carte;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CarteTest {
+    @Test
+    void getValeurTuileOutOfBounds() {
+        int[][] grid = {{1}};
+        Carte carte = new Carte(grid);
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(-1, 0));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(0, -1));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(1, 0));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(0, 1));
+    }
+
+    @Test
+    void setValeurTuileModifieSiValide() {
+        int[][] grid = {{0,0},{0,0}};
+        Carte carte = new Carte(grid);
+        carte.setValeurTuile(1,1,5);
+        assertEquals(5, carte.getValeurTuile(1,1));
+        carte.setValeurTuile(2,0,9);
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(2,0));
+    }
+
+    @Test
+    void estSolidePrendEnCompteListeNonSolide() {
+        int[][] grid = {{0,29}};
+        Carte carte = new Carte(grid);
+        assertFalse(carte.estSolide(0,0));
+        assertTrue(carte.estSolide(0,1));
+    }
+
+    @Test
+    void chercherLigneSolRenvoieBonneLigne() {
+        int[][] grid = {
+            {-1,-1},
+            {1,0},
+            {29,29}
+        };
+        Carte carte = new Carte(grid);
+        assertEquals(2, carte.chercherLigneSol(0));
+        assertEquals(2, carte.chercherLigneSol(1));
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/item/InventaireTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/item/InventaireTest.java
@@ -1,0 +1,36 @@
+package fr.iut.groupe.junglequest.modele.item;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InventaireTest {
+    @Test
+    void ajouterEtContientItem() {
+        Inventaire inv = new Inventaire();
+        assertTrue(inv.ajouterItem("Bois", 3));
+        assertTrue(inv.contient("Bois", 3));
+        assertFalse(inv.ajouterItem("Pierre", 0));
+    }
+
+    @Test
+    void retirerItemFonctionne() {
+        Inventaire inv = new Inventaire();
+        inv.ajouterItem("Bois", 5);
+
+        assertTrue(inv.retirerItem("Bois", 3));
+        assertEquals(2, inv.getItems().get("Bois"));
+        assertFalse(inv.retirerItem("Bois", 3));
+        assertTrue(inv.retirerItem("Bois", 2));
+        assertFalse(inv.getItems().containsKey("Bois"));
+    }
+
+    @Test
+    void viderSupprimeTout() {
+        Inventaire inv = new Inventaire();
+        inv.ajouterItem("Bois", 1);
+        inv.ajouterItem("Pierre", 2);
+        inv.vider();
+        assertTrue(inv.getItems().isEmpty());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/monde/AStarTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/monde/AStarTest.java
@@ -1,0 +1,36 @@
+package fr.iut.groupe.junglequest.modele.monde;
+
+import fr.iut.groupe.junglequest.modele.carte.Carte;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AStarTest {
+    @Test
+    void chercherCheminSimple() {
+        int[][] grid = {
+                {0,0,0},
+                {0,29,0},
+                {0,0,0}
+        };
+        Carte carte = new Carte(grid);
+        List<int[]> path = AStar.chercherChemin(carte,0,0,2,2);
+        assertFalse(path.isEmpty());
+        assertArrayEquals(new int[]{0,0}, path.get(0));
+        assertArrayEquals(new int[]{2,2}, path.get(path.size()-1));
+    }
+
+    @Test
+    void chercherCheminBloqueRenvoieVide() {
+        int[][] grid = {
+                {0,29,0},
+                {29,29,29},
+                {0,29,0}
+        };
+        Carte carte = new Carte(grid);
+        List<int[]> path = AStar.chercherChemin(carte,0,0,2,2);
+        assertTrue(path.isEmpty());
+    }
+}

--- a/src/test/java/fr/iut/groupe/junglequest/modele/personnages/PersonnageTest.java
+++ b/src/test/java/fr/iut/groupe/junglequest/modele/personnages/PersonnageTest.java
@@ -1,0 +1,46 @@
+package fr.iut.groupe.junglequest.modele.personnages;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersonnageTest {
+
+    static class TestPerso extends Personnage {
+        TestPerso() { super(0,0,10,10); }
+    }
+
+    @Test
+    void sautUniquementAuSol() {
+        TestPerso p = new TestPerso();
+        p.setEstAuSol(true);
+        p.sauter(5);
+        assertEquals(-5, p.getVitesseY());
+        assertFalse(p.estAuSol());
+        p.sauter(5);
+        assertEquals(-5, p.getVitesseY());
+    }
+
+    @Test
+    void appliquerGraviteLimiteLaVitesse() {
+        TestPerso p = new TestPerso();
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        p.appliquerGravite(1,3);
+        assertEquals(3, p.getVitesseY());
+    }
+
+    @Test
+    void deplacementGaucheDroiteEtArret() {
+        TestPerso p = new TestPerso();
+        p.deplacerDroite(2);
+        assertEquals(2, p.getVitesseX());
+        assertFalse(p.estVersGauche());
+        p.deplacerGauche(1);
+        assertEquals(-1, p.getVitesseX());
+        assertTrue(p.estVersGauche());
+        p.arreter();
+        assertEquals(0, p.getVitesseX());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `Inventaire`
- add tests for `Carte`
- test `TileType` enum
- add pathfinding tests for `AStar`
- add movement and physics tests for `Personnage`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855a866cebc832390387448064d617a